### PR TITLE
test(fuzz): add X12 interchange fuzzers seeded from examples

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,39 @@
+name: Go Fuzz Testing
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - "go test ./test/fuzz/... -fuzz FuzzReaderWriterX12 -fuzztime 10m"
+
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v7
+      with:
+        go-version: stable
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Fuzz
+      run: ${{ matrix.command }}
+
+    - name: Report Failures
+      if: ${{ failure() }}
+      run: |
+        find . -path '*/testdata/fuzz/*' -type f 2>/dev/null | xargs -r -n1 tail -n +1 -v || true

--- a/cmd/x12/main.go
+++ b/cmd/x12/main.go
@@ -165,7 +165,7 @@ func describeFile(paths []string, rule rules.InterchangeRule, validateFlag bool)
 		}
 
 		if validateFlag {
-			if f.Validate() == nil {
+			if err := f.Validate(); err == nil {
 				fmt.Fprintf(os.Stdout, "The edi file is valid(%s)\n", path)
 			} else {
 				fmt.Fprintf(os.Stdout, "Failed to validate edi(%s): %v\n", path, err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -103,13 +103,13 @@ func DumpStructInfo(r any, level int) ElementInfo {
 			} else if elm.Kind() == reflect.Struct {
 				method := elm.MethodByName("String")
 				if method.IsValid() {
-					response := method.Call(nil)
+					response := method.Call(nil) //nolint:forbidigo // reflect.Value.Call for String()
 					info.Items = append(info.Items, response[0].String())
 				}
 			} else if elm.Kind() == reflect.Ptr && !elm.IsNil() {
 				method := reflect.ValueOf(elm.Interface()).MethodByName("String")
 				if method.IsValid() {
-					response := method.Call(nil)
+					response := method.Call(nil) //nolint:forbidigo // reflect.Value.Call for String()
 					info.Items = append(info.Items, response[0].String())
 				}
 			}

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -1,0 +1,66 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package fuzz
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moov-io/x12/pkg/file"
+	"github.com/moov-io/x12/pkg/rules"
+	rule4010810 "github.com/moov-io/x12/rules/rule_4010_810"
+	rule5010835 "github.com/moov-io/x12/rules/rule_5010_835"
+	rule5010837p "github.com/moov-io/x12/rules/rule_5010_837p"
+	rulestp820 "github.com/moov-io/x12/rules/rule_stp_820"
+)
+
+func FuzzReaderWriterX12(f *testing.F) {
+	populateCorpus(f)
+
+	ruleSet := []*rules.InterchangeRule{
+		&rule5010835.InterchangeRule,
+		&rule5010837p.InterchangeRule,
+		&rule4010810.InterchangeRule,
+		&rulestp820.InterchangeRule,
+	}
+
+	f.Fuzz(func(t *testing.T, contents string) {
+		if len(contents) > 1<<20 {
+			t.Skip()
+		}
+
+		for _, rule := range ruleSet {
+			fl := file.NewFile(rule)
+			_ = fl.Parse(file.NewScanner(strings.NewReader(contents)))
+			_ = fl.Validate()
+			_ = fl.String()
+		}
+	})
+}
+
+func populateCorpus(f *testing.F) {
+	f.Helper()
+
+	f.Add("")
+	f.Add("ISA*")
+	f.Add("ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *250101*1200*^*00501*000000001*0*P*:~")
+
+	_ = filepath.Walk(filepath.Join("..", "..", "examples"), func(path string, info fs.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(strings.ToLower(path), ".txt") {
+			bs, err := os.ReadFile(path)
+			if err != nil || len(bs) > 512*1024 {
+				return nil
+			}
+			f.Add(string(bs))
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary
Add native Go fuzzers that parse arbitrary input with 5010 835/837p, 4010 810, and STP 820 interchange rules. Seeds come from `examples/**/*.txt`.

## Test plan
- [x] `go test` for affected packages
- [x] `go test -run='^$' -fuzz=Fuzz... -fuzztime=3s` smoke on new/updated fuzzers
- [x] Regression tests for any panics fixed by fuzzing